### PR TITLE
meson: fix missing semicolon when generating def for GCC

### DIFF
--- a/packaging/makedef.py
+++ b/packaging/makedef.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     else:
         print(f"{libname.stem.replace('.', '_')} {{")
         print("\tglobal:")
-        print(";\n".join(sorted(set([f'\t\t{i}' for i in dump]))))
+        print(";\n".join(sorted(set([f'\t\t{i}' for i in dump]))) + ';')
         print("\tlocal:")
         print("\t\t*;")
         print("};")


### PR DESCRIPTION
Recent versions of GNU LD seems to not like missing semicolons in version scripts definition.

This adds the missing semicolon on the last global entry and fix build on those version of GNU LD.

Fixes: c8733de46f04 ("meson: Extend the symbol exports to Darwin and Unix")

/cc @dragonmux